### PR TITLE
made keys optional and return meta additionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ import CsvParse from '@vtex/react-csv-parse'
 ```
 
 ```jsx
-handleData = data => {
-  this.setState({ data })
+handleData = (data, meta) => {
+  this.setState({ data, meta })
 }
 ```
 
@@ -93,7 +93,7 @@ render() {
 
   return (
     <CsvParse
-      keys={keys}
+      keys={keys} // remove if you want firstline as header
       onDataUploaded={this.handleData}
       onError={this.handleError}
       render={onChange => <input type="file" onChange={onChange} />}
@@ -110,8 +110,8 @@ calls the child function and renders that. Wrap everything in
 
 | Prop name        | Type  | Default | Required | Description                                                                    |
 | ---------------- | ----- | ------- | -------- | ------------------------------------------------------------------------------ |
-| `keys`           | array |         | true     | The keys used to create the objects.                                           |
-| `onDataUploaded` | func  |         | true     | Callback function with the data parsed as parameter.                           |
+| `keys`           | array |         | false    | The keys used to create the objects otherwise use firstline as header.         |
+| `onDataUploaded` | func  |         | true     | Callback function with the data and meta parsed as parameter.                  |
 | `onError`        | func  |         | false    | Callback function with the following data: `{ err, file, inputElem, reason }`. |
 
 ### Data split rules

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -12,12 +12,12 @@ class Demo extends React.Component {
     }
   }
 
-  handleData = data => {
-    this.setState({ data })
+  handleData = (data, meta) => {
+    this.setState({ data, meta })
   }
 
   handleError = error => {
-    this.setState({ error })
+    this.setState({ error, data: null, meta: null })
   }
 
   render() {
@@ -40,6 +40,7 @@ class Demo extends React.Component {
       <div>
         <h1>Demo React Csv Parse</h1>
 
+        <h2>With keys</h2>
         <CsvParse
           keys={keys}
           onDataUploaded={this.handleData}
@@ -47,10 +48,24 @@ class Demo extends React.Component {
           render={onChange => <input type="file" onChange={onChange} />}
         />
 
+        <h2>Without specific keys</h2>
+        <CsvParse
+          onDataUploaded={this.handleData}
+          onError={this.handleError}
+          render={onChange => <input type="file" onChange={onChange} />}
+        />
+
+        <h2>Data</h2>
         {this.state.data && (
           <pre>{JSON.stringify(this.state.data, null, 2)}</pre>
         )}
 
+        <h2>Meta</h2>
+        {this.state.meta && (
+          <pre>{JSON.stringify(this.state.meta, null, 2)}</pre>
+        )}
+
+        <h2>Error</h2>
         {this.state.error && (
           <pre>{JSON.stringify(this.state.error, null, 2)}</pre>
         )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/react-csv-parse",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "react-csv-parse React component",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -7,23 +7,26 @@ import { apply, compose, lift, splitAt, zipObj } from 'ramda'
 class CsvParse extends React.Component {
   handleFile = event => {
     const file = event.target.files[0]
-    const keys = this.props.keys
+    const keys = this.props.keys 
     const onDataUploaded = this.props.onDataUploaded
     const onError = this.props.onError
 
     Papa.parse(file, {
       skipEmptyLines: true,
-      error: function(err, file, inputElem, reason) {
+      error: function (err, file, inputElem, reason) {
         onError({ err, file, inputElem, reason })
       },
-      complete: function(results) {
+      complete: function (results) {
         const data = results.data
+        const meta = results.meta
 
-        // remove display headers
-        data.shift()
+        if (keys) {
+          // remove display headers
+          data.shift()
 
-        // add api headers
-        data.unshift(keys)
+          // add api headers
+          data.unshift(keys)
+        }
 
         // convert arrays to objects
         const formatedResult = compose(
@@ -32,7 +35,7 @@ class CsvParse extends React.Component {
         )(data)
 
         // send result to state
-        onDataUploaded(formatedResult)
+        onDataUploaded(formatedResult, meta)
       },
     })
   }
@@ -43,7 +46,7 @@ class CsvParse extends React.Component {
 }
 
 CsvParse.propTypes = {
-  keys: PropTypes.array.isRequired,
+  keys: PropTypes.array,
   onDataUploaded: PropTypes.func.isRequired,
   onError: PropTypes.func,
 }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -19,4 +19,15 @@ describe('CsvParse', () => {
       ),
     ).toContain('<input type="file"/>')
   })
+
+  it('renders an input with type="file" without "keys"', () => {
+    expect(
+      render(
+        <CsvParse
+          onDataUploaded={mockFunc}
+          render={onChange => <input type="file" />}
+        />,
+      ),
+    ).toContain('<input type="file"/>')
+  })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?
made keys optional and return meta additionally

#### What problem is this solving?
- Be more flexible without knowing all columns of the csv or restricting to (e.g. use in NOSQL)
- Get the meta as additional result

#### How should this be manually tested?
As before 
#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
